### PR TITLE
[Fixed]rails g controllerで不要なhelperやassetsを生成しない

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,9 +57,13 @@ gem 'twitter-bootstrap-rails'
 gem 'jquery-turbolinks'
 gem 'rails_12factor', group: :production
 
+
 group :development do
   gem 'letter_opener_web'
   gem 'web-console', '~> 2.0'
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,10 @@ module Achieve
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'


### PR DESCRIPTION
#3 config/application.rbに

config.generators do |g|
      g.assets     false
      g.helper     false
    end

を追加した